### PR TITLE
Remove OR from config.ipadr

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,7 +27,7 @@ var app = express();
 var config = {
     log: true,
     readline: false, //This is breaking on some machines, also to be deprecated with express routes.
-    ipadr: '127.0.0.1' || 'localhost',
+    ipadr: '127.0.0.1',
     port: 3000,
     ssl: false
 };


### PR DESCRIPTION
`'127.0.0.1' || 'localhost'` will always result in `127.0.0.1` since all non-empty strings are truthy, so there's no real reason to have it.